### PR TITLE
Fix live toggle behavior for nested tags and offscreen content

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,13 +1,43 @@
 ## Obsidian Float
-This is a plugin for Obsidian which enhances the current highlight feature of Obsidian by adding better animations to focus more on the highlights as you scroll down while in reading mode.
+This plugin enhances Obsidian reading mode by animating highlighted content as it enters the viewport, so attention stays on important text while scrolling.
+
+## Features
+
+- Supports animated float effects for:
+  - Highlights (`==text==` / `<mark>`)
+  - Bold (`**text**` / `<strong>`)
+  - Italic (`*text*` / `<em>`)
+- Per-tag controls:
+  - Enable/disable animation per tag type
+  - Independent scale amount per tag type
+- Global controls:
+  - Animation duration
+  - Background opacity dimming for non-highlighted content
+  - Animate word only (instead of full container block)
+  - Animate bold/italic inside highlight blocks
+- Scroll performance improvements:
+  - Transform-only highlight transition for smoother scrolling
+  - Ultra-smooth scrolling behavior that temporarily removes shadow while actively scrolling, then restores it when scrolling stops
 
 ## Usage
 
 1. Use Obsidian's built-in highlight syntax to mark text: `==your highlighted text==`
-2. Switch to **Reading mode** (the plugin does not work in Live Preview or Source mode)
-3. Scroll through your note — highlighted blocks will animate into focus as they enter the viewport
+2. (Optional) In plugin settings, enable bold/italic animations and tune scale/duration
+3. Switch to **Reading mode** (the plugin does not work in Live Preview or Source mode)
+4. Scroll through your note — configured elements animate into focus as they enter the viewport
 
-`Note`: The entire text block (paragraph, list item, heading, etc.) containing the highlighted word will be animated, not just the highlighted word itself.
+`Note`: By default, the entire container block (paragraph, list item, heading, etc.) is animated. Enable `Animate word only` in settings to animate just the matched word/inline element.
+
+## Settings Overview
+
+- Global:
+  - `Animation duration`
+  - `Background opacity`
+  - `Animate word only`
+  - `Animate bold/italic inside highlights`
+- Per tag (Highlights, Bold, Italic):
+  - `Enable ... float`
+  - `... scale amount`
 
 ## Demo
 

--- a/docs/development-log.md
+++ b/docs/development-log.md
@@ -1,0 +1,107 @@
+# Floating Highlights - Development Log
+
+## Issue #2: User Unable to Use Plugin
+
+A user (Representat) reported they couldn't install or use the plugin. The conversation went through several phases:
+
+1. **Installation fix** - Plugin wasn't downloadable from community plugins. Fixed in v1.0.3 release.
+2. **Highlighting not working** - User tried bold, italic, and `<span>` tags. The plugin only supports Obsidian's `==highlight==` syntax (renders as `<mark>` tags). This was the root cause.
+3. **README updated** - Added a Usage section clarifying the `==highlight==` syntax and Reading mode requirement.
+
+### Feature Requests from the Issue
+
+The user then requested:
+1. Support for `<strong>` (bold) and `<em>` (italic) tags
+2. Customizable block size/scale via settings
+3. Different scaling per tag type (e.g., bold scales more than italic)
+
+---
+
+## Features Implemented (branch: `feat/multi-tag-settings`)
+
+### Commit: `c629a32` - Multi-tag support, per-tag scaling, and settings panel
+
+**Changes to `main.ts`:**
+- Added `PluginSettingTab`, `App`, `Setting` imports
+- `SupportedTag` type (`'mark' | 'strong' | 'em'`) and `SUPPORTED_TAGS` array
+- `TagSettings` interface (enabled, scaleAmount) and `FloatHighlightsSettings` interface
+- Per-tag defaults: mark (enabled, 1.1), strong (disabled, 1.08), em (disabled, 1.05)
+- Dynamic element detection: `querySelectorAll("mark")` changed to a selector built from enabled tags
+- `data-float-tag` attribute on containers for per-tag CSS scale
+- `applyStyles()` sets CSS variables on `document.body`
+- Deep-merge in `loadSettings()` for backward compatibility
+- Full settings tab with global controls (animation duration) and per-tag controls (enable toggle, scale slider)
+- Observer cleanup in `onunload()`
+
+**Changes to `styles.css`:**
+- CSS variables for duration and per-tag scales
+- Three `[data-float-tag]` selectors for mark, strong, em
+
+### Commit: `22c1273` - Word-only animation, inside-highlight control, performance
+
+**New settings:**
+- `animateWordOnly` - Animate just the word instead of the entire block
+- `animateInsideHighlight` - Whether to animate bold/italic inside `==highlight==` blocks (default: off)
+
+**Performance improvements:**
+- Scoped CSS transitions to `transform` and `box-shadow` only (was `all`)
+- `WeakSet` to prevent duplicate container observations
+- Skip redundant DOM writes in observer callback (check state before writing)
+
+**Removed:** Block padding setting (not visually useful)
+
+**Word-level styles:**
+- `display: inline-block` for transforms to work on inline elements
+- `mark.float-highlights`: keeps highlight background color, no border
+- `strong/em.float-highlights`: transparent background, keeps border/shadow
+
+### Commit: `9d2e0ba` - Background opacity setting
+
+- New `backgroundOpacity` setting (0.1 to 1.0, slider)
+- Toggles `float-highlights-active` class on body when any highlight is visible
+- Tracks active highlight count to manage the body class
+- CSS dims non-highlighted block elements using `:has(.float-highlights)` to exclude parents of highlighted elements (prevents opacity cascading)
+
+---
+
+## Design Decisions
+
+### Word-only mode styling
+- `mark` elements: keep native highlight color, remove border (looks natural)
+- `strong`/`em` elements: transparent background, keep border/shadow (matches block style)
+- Both: `display: inline-block` required for CSS transforms on inline elements
+
+### Background dimming approach
+Several approaches were tried:
+1. **Per-element opacity with `:not(.float-highlights)`** - Failed because parent elements (e.g., `<li>` containing `<p class="float-highlights">`) were dimmed, and CSS opacity cascades from parent to child
+2. **`body::after` overlay with z-index** - Covered the entire Obsidian UI, not just reading content. z-index conflicts with nested stacking contexts.
+3. **Per-element opacity with `:not(:has(.float-highlights))`** - Works correctly. The `:has()` selector excludes parent elements that contain a highlighted child, preventing cascading opacity issues.
+
+### Performance considerations
+- `transform` and `opacity` are the only GPU-composited CSS properties (cheap to animate)
+- `box-shadow` is expensive to transition (repainted every frame) but fine when static
+- `will-change: transform` promotes elements to compositor layers (good for ~10-50 elements)
+- IntersectionObserver already fires between frames; wrapping in `requestAnimationFrame` adds unnecessary delay
+- CSS `:has()` is well-optimized in modern Chromium and not a scroll performance bottleneck
+
+---
+
+## Current State
+
+### Scroll performance fixes implemented
+- CSS now transitions only `transform` on `.float-highlights`
+- Reduced shadow blur radius to reduce paint cost
+- Kept `will-change: transform` for animated highlight elements
+- Reverted dimming from JS TreeWalker bookkeeping to CSS `:has()` selector
+- Removed the extra `requestAnimationFrame` wrapper from the IntersectionObserver callback
+- Removed class-toggle layout costs (`margin`, `padding`, `border`) and switched to `outline` for highlight framing
+
+### File structure:
+- `main.ts` - Plugin source (~220 lines)
+- `styles.css` - Plugin styles
+- `manifest.json` - v1.0.3
+- `README.md` - Updated with usage instructions
+
+### Settings UI layout:
+- **Global**: Animation duration, Background opacity, Animate word only, Animate bold/italic inside highlights
+- **Per-tag** (Highlights, Bold, Italic): Enable toggle, Scale amount slider

--- a/docs/state-diagram.md
+++ b/docs/state-diagram.md
@@ -1,0 +1,79 @@
+# Float Animation State Diagram
+
+This document defines how animation eligibility is decided for `mark`, `strong`, and `em`.
+
+## Inputs
+
+- `Tag`: `mark` | `strong` | `em`
+- `InsideHighlight`: whether `strong`/`em` is nested inside a `mark`
+- `Enable highlight float` (`mark.enabled`)
+- `Enable bold float` (`strong.enabled`)
+- `Enable italic float` (`em.enabled`)
+- `Animate bold/italic inside highlights` (`animateInsideHighlight`)
+- `Animate word only` (`animateWordOnly`) - affects animation target, not eligibility
+
+## Decision Flow
+
+```mermaid
+flowchart TD
+    A[Element discovered] --> B{Tag type}
+    B -->|mark| C{mark.enabled}
+    C -->|yes| Z[Observe and animate]
+    C -->|no| X[Do not observe]
+
+    B -->|strong or em| D{tag.enabled}
+    D -->|no| X
+    D -->|yes| E{Inside mark?}
+    E -->|no| Z
+    E -->|yes| F{animateInsideHighlight}
+    F -->|yes| Z
+    F -->|no| X
+```
+
+## Priority Rules
+
+- In block mode (`animateWordOnly = false`), multiple active tags can map to the same container.
+- Effective visual tag priority is:
+  1. `mark`
+  2. `strong`
+  3. `em`
+- Therefore, if a highlight is active in a container, highlight animation wins for that container.
+
+## Truth Table
+
+### `mark` element
+
+| mark.enabled | Animate mark? |
+|---|---|
+| false | No |
+| true | Yes |
+
+### `strong` or `em` outside highlight
+
+| tag.enabled | Animate tag? |
+|---|---|
+| false | No |
+| true | Yes |
+
+### `strong` or `em` inside highlight
+
+| tag.enabled | animateInsideHighlight | Animate nested tag? |
+|---|---|---|
+| false | false/true | No |
+| true | false | No |
+| true | true | Yes |
+
+## Static.md Test Matrix
+
+Testing file: `/home/karthikraju/notes/Technical/OOP/Static.md`
+
+- Nested bold inside highlight sample: line 8 (`==... **before any objects exist** ...==`)
+- Nested bold inside highlight sample: line 69 (`==... **resolving** ...==`)
+- Independent bold/italic sample: line 5 (`*methods*`, `**static**`)
+
+Expected:
+
+1. `mark=ON`, `strong=OFF`, `em=OFF`: line 8/69 highlight still animates.
+2. `mark=OFF`, `strong=ON`, `em=ON`, `animateInsideHighlight=ON`: nested bold/italic in line 8/69 animates.
+3. `mark=OFF`, `strong=ON`, `em=ON`, `animateInsideHighlight=OFF`: nested bold/italic in line 8/69 does not animate; line 5 bold/italic still animate.
+4. `mark=ON`, `strong=ON`, `em=ON`, `animateInsideHighlight=ON`: highlight remains primary in block mode; nested inline animations appear when using word-only mode.

--- a/main.ts
+++ b/main.ts
@@ -1,43 +1,174 @@
-import { Plugin } from 'obsidian';
+import { Plugin, PluginSettingTab, App, Setting } from 'obsidian';
+
+type SupportedTag = 'mark' | 'strong' | 'em';
+const SUPPORTED_TAGS: SupportedTag[] = ['mark', 'strong', 'em'];
+
+interface TagSettings {
+	enabled: boolean;
+	scaleAmount: number;
+}
+
+interface FloatHighlightsSettings {
+	mark: TagSettings;
+	strong: TagSettings;
+	em: TagSettings;
+	animationDuration: number;
+	padding: number;
+}
+
+const DEFAULT_SETTINGS: FloatHighlightsSettings = {
+	mark: { enabled: true, scaleAmount: 1.1 },
+	strong: { enabled: false, scaleAmount: 1.08 },
+	em: { enabled: false, scaleAmount: 1.05 },
+	animationDuration: 150,
+	padding: 1.0,
+};
 
 function getHighlightContainer(el: HTMLElement): HTMLElement | null {
-	return (el.closest('p, li, blockquote, td, th') as HTMLElement | null) ?? el.parentElement;
+	return (el.closest('p, li, blockquote, td, th, h1, h2, h3, h4, h5, h6') as HTMLElement | null) ?? el.parentElement;
 }
 
 export default class FloatHighlightsPlugin extends Plugin {
-	onload() {
-		console.log("loading plugin");
+	settings: FloatHighlightsSettings;
+	private observer: IntersectionObserver;
 
-		const highlightObserver = new IntersectionObserver((entries) => {
+	async onload() {
+		await this.loadSettings();
+		this.applyStyles();
+		this.addSettingTab(new FloatHighlightsSettingTab(this.app, this));
+
+		this.observer = new IntersectionObserver((entries) => {
 			entries.forEach((entry) => {
 				const target = entry.target as HTMLElement;
 				const container = getHighlightContainer(target);
-				if (!container) {
-					return;
-				}
+				if (!container) return;
 
 				if (entry.isIntersecting) {
 					container.classList.add("float-highlights");
+					container.setAttribute("data-float-tag", target.tagName.toLowerCase());
 				} else {
 					container.classList.remove("float-highlights");
+					container.removeAttribute("data-float-tag");
 				}
 			});
 		}, { threshold: 0.2 });
 
 		this.registerMarkdownPostProcessor((element) => {
-			const highlightElements = element.querySelectorAll("mark");
-			if (highlightElements) {
-				Array.from(highlightElements).forEach((el) => {
-					const mark = el as HTMLElement;
-					if (getHighlightContainer(mark)) {
-						highlightObserver.observe(mark);
-					}
-				});
-			}
+			const enabledTags = SUPPORTED_TAGS.filter(tag => this.settings[tag].enabled);
+			if (enabledTags.length === 0) return;
+
+			const selector = enabledTags.join(", ");
+			const matchedElements = element.querySelectorAll(selector);
+
+			matchedElements.forEach((el) => {
+				const htmlEl = el as HTMLElement;
+				if (getHighlightContainer(htmlEl)) {
+					this.observer.observe(htmlEl);
+				}
+			});
 		});
 	}
 
 	onunload() {
-		console.log("Unloading plugin")
+		this.observer?.disconnect();
+	}
+
+	async loadSettings() {
+		const data = (await this.loadData()) || {};
+		this.settings = {
+			mark: { ...DEFAULT_SETTINGS.mark, ...data.mark },
+			strong: { ...DEFAULT_SETTINGS.strong, ...data.strong },
+			em: { ...DEFAULT_SETTINGS.em, ...data.em },
+			animationDuration: data.animationDuration ?? DEFAULT_SETTINGS.animationDuration,
+			padding: data.padding ?? DEFAULT_SETTINGS.padding,
+		};
+	}
+
+	async saveSettings() {
+		await this.saveData(this.settings);
+		this.applyStyles();
+	}
+
+	private applyStyles(): void {
+		const body = document.body;
+		body.style.setProperty('--float-mark-scale', this.settings.mark.scaleAmount.toString());
+		body.style.setProperty('--float-strong-scale', this.settings.strong.scaleAmount.toString());
+		body.style.setProperty('--float-em-scale', this.settings.em.scaleAmount.toString());
+		body.style.setProperty('--float-duration', `${this.settings.animationDuration}ms`);
+		body.style.setProperty('--float-padding', `${this.settings.padding}em`);
+	}
+}
+
+class FloatHighlightsSettingTab extends PluginSettingTab {
+	plugin: FloatHighlightsPlugin;
+
+	constructor(app: App, plugin: FloatHighlightsPlugin) {
+		super(app, plugin);
+		this.plugin = plugin;
+	}
+
+	display(): void {
+		const { containerEl } = this;
+		containerEl.empty();
+
+		containerEl.createEl('h3', { text: 'Global Settings' });
+
+		new Setting(containerEl)
+			.setName('Animation duration')
+			.setDesc('Duration of the float animation in milliseconds')
+			.addSlider(slider => slider
+				.setLimits(50, 500, 10)
+				.setValue(this.plugin.settings.animationDuration)
+				.setDynamicTooltip()
+				.onChange(async (value) => {
+					this.plugin.settings.animationDuration = value;
+					await this.plugin.saveSettings();
+				}));
+
+		new Setting(containerEl)
+			.setName('Block padding')
+			.setDesc('Padding around the animated block (in em units)')
+			.addSlider(slider => slider
+				.setLimits(0, 2, 0.1)
+				.setValue(this.plugin.settings.padding)
+				.setDynamicTooltip()
+				.onChange(async (value) => {
+					this.plugin.settings.padding = value;
+					await this.plugin.saveSettings();
+				}));
+
+		const tagLabels: Record<SupportedTag, { name: string; syntax: string }> = {
+			mark: { name: 'Highlights', syntax: '==text==' },
+			strong: { name: 'Bold', syntax: '**text**' },
+			em: { name: 'Italic', syntax: '*text*' },
+		};
+
+		for (const tag of SUPPORTED_TAGS) {
+			const label = tagLabels[tag];
+
+			containerEl.createEl('h3', { text: `${label.name} (${label.syntax})` });
+
+			new Setting(containerEl)
+				.setName(`Enable ${label.name.toLowerCase()} float`)
+				.setDesc(`Apply float animation to ${label.syntax} text`)
+				.addToggle(toggle => toggle
+					.setValue(this.plugin.settings[tag].enabled)
+					.onChange(async (value) => {
+						this.plugin.settings[tag].enabled = value;
+						await this.plugin.saveSettings();
+					}));
+
+			new Setting(containerEl)
+				.setName(`${label.name} scale amount`)
+				.setDesc(`How much to scale ${label.syntax} blocks (1.0 = no scale)`)
+				.addSlider(slider => slider
+					.setLimits(1.0, 1.5, 0.01)
+					.setValue(this.plugin.settings[tag].scaleAmount)
+					.setDynamicTooltip()
+					.onChange(async (value) => {
+						this.plugin.settings[tag].scaleAmount = value;
+						await this.plugin.saveSettings();
+					}));
+		}
 	}
 }

--- a/styles.css
+++ b/styles.css
@@ -48,3 +48,9 @@ strong.float-highlights,
 em.float-highlights {
     background: transparent;
 }
+
+/* Dim non-highlighted content when highlights are active */
+body.float-highlights-active :is(p, li, blockquote, td, th, h1, h2, h3, h4, h5, h6, pre):not(.float-highlights):not(:has(.float-highlights)) {
+    opacity: var(--float-bg-opacity, 1);
+    transition: opacity var(--float-duration, 150ms) ease;
+}

--- a/styles.css
+++ b/styles.css
@@ -8,13 +8,18 @@ If your plugin does not need CSS, delete this file.
 */
 
 .float-highlights {
-    transition: transform var(--float-duration, 150ms) ease, box-shadow var(--float-duration, 150ms) ease;
+    transition: transform var(--float-duration, 150ms) ease;
     margin: 1em 0 1em 0 !important;
-    box-shadow: rgba(0, 0, 0, 0.45) 0px 22px 53px 4px;
+    box-shadow: rgba(0, 0, 0, 0.35) 0px 12px 28px 2px;
     border: 1px solid white;
     padding: 1em !important;
     border-radius: 0.5em;
     list-style-type: none;
+}
+
+/* Ultra-smooth mode: remove expensive shadows while actively scrolling */
+body.float-scroll-active .float-highlights {
+    box-shadow: none;
 }
 
 .float-highlights[data-float-tag="mark"] {

--- a/styles.css
+++ b/styles.css
@@ -8,12 +8,23 @@ If your plugin does not need CSS, delete this file.
 */
 
 .float-highlights {
-    transition: all 150ms ease;
+    transition: all var(--float-duration, 150ms) ease;
     margin: 1em 0 1em 0 !important;
-    transform: scale(1.1);
     box-shadow: rgba(0, 0, 0, 0.45) 0px 22px 53px 4px;
     border: 1px solid white;
-    padding: 1em !important;
+    padding: var(--float-padding, 1em) !important;
     border-radius: 0.5em;
     list-style-type: none;
+}
+
+.float-highlights[data-float-tag="mark"] {
+    transform: scale(var(--float-mark-scale, 1.1));
+}
+
+.float-highlights[data-float-tag="strong"] {
+    transform: scale(var(--float-strong-scale, 1.08));
+}
+
+.float-highlights[data-float-tag="em"] {
+    transform: scale(var(--float-em-scale, 1.05));
 }

--- a/styles.css
+++ b/styles.css
@@ -8,11 +8,11 @@ If your plugin does not need CSS, delete this file.
 */
 
 .float-highlights {
-    transition: all var(--float-duration, 150ms) ease;
+    transition: transform var(--float-duration, 150ms) ease, box-shadow var(--float-duration, 150ms) ease;
     margin: 1em 0 1em 0 !important;
     box-shadow: rgba(0, 0, 0, 0.45) 0px 22px 53px 4px;
     border: 1px solid white;
-    padding: var(--float-padding, 1em) !important;
+    padding: 1em !important;
     border-radius: 0.5em;
     list-style-type: none;
 }
@@ -27,4 +27,24 @@ If your plugin does not need CSS, delete this file.
 
 .float-highlights[data-float-tag="em"] {
     transform: scale(var(--float-em-scale, 1.05));
+}
+
+/* Word-level animation: inline elements need inline-block for transforms */
+mark.float-highlights,
+strong.float-highlights,
+em.float-highlights {
+    display: inline-block;
+    margin: 0.2em 0 !important;
+    padding: 0.3em 0.5em !important;
+}
+
+/* Highlights keep their background color, no border */
+mark.float-highlights {
+    border: none;
+}
+
+/* Bold/italic get transparent background */
+strong.float-highlights,
+em.float-highlights {
+    background: transparent;
 }


### PR DESCRIPTION
## Summary
- Fixes toggle updates so behavior applies across rendered content without reopening notes.
- Refactors float eligibility/state handling for `mark` / `strong` / `em` with explicit priority and independent enablement rules.
- Ensures nested `strong`/`em` inside highlights respect `Animate bold/italic inside highlights` while keeping highlight animation independent.
- Adds DOM/scroll-driven re-observation so lazily rendered preview chunks are picked up.
- Documents behavior and test matrix in `docs/state-diagram.md` and updates README features/settings.

## Key Changes
- `main.ts`
  - Added stable per-target + per-container contribution tracking.
  - Always observes rendered `mark/strong/em` elements and applies eligibility based on current settings.
  - Added live refresh for setting toggles and preview-root rescans.
  - Added mutation observer + pane scroll capture to detect newly mounted rendered content.
- `README.md`
  - Expanded feature and settings documentation.
- `docs/state-diagram.md`
  - Added state diagram, truth table, and `Static.md`-based test matrix.

## Validation
- Built successfully with `npm run build`.
- Manual testing performed against `/home/karthikraju/notes/Technical/OOP/Static.md` for nested highlight/bold/italic toggle combinations.
